### PR TITLE
Add Basic Project Filters

### DIFF
--- a/src/Map/DependencyMapper/src/Context/MethodDependencyMappingContext.cs
+++ b/src/Map/DependencyMapper/src/Context/MethodDependencyMappingContext.cs
@@ -1,4 +1,5 @@
-﻿using Iceberg.Map.Metadata;
+﻿using Iceberg.Map.DependencyMapper.Filters.Projects;
+using Iceberg.Map.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
 
@@ -14,6 +15,7 @@ public interface IMethodDependencyMappingContext
 
     Task MapDownstream(
         IEntryPoint<MethodDeclarationSyntax> methodEntryPoint,
+        IProjectFilter projectFilter,
         CancellationToken cancellationToken = default);
 }
 
@@ -81,6 +83,7 @@ internal partial class MethodDependencyMappingContext : IMethodDependencyMapping
 
     public async Task MapDownstream(
         IEntryPoint<MethodDeclarationSyntax> methodEntryPoint,
+        IProjectFilter projectFilter,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(methodEntryPoint.DisplayName))
@@ -102,7 +105,7 @@ internal partial class MethodDependencyMappingContext : IMethodDependencyMapping
         var dependencyEntryPoints = new HashSet<IEntryPoint<MethodDeclarationSyntax>>();
         var dependencyEntryPointMetadata = new HashSet<MethodMetadata>();
 
-        await foreach (var dependencyEntryPoint in _solutionContext.FindDownstreamDependencyEntryPoints(methodEntryPoint, cancellationToken))
+        await foreach (var dependencyEntryPoint in _solutionContext.FindDownstreamDependencyEntryPoints(methodEntryPoint, projectFilter, cancellationToken))
         {
             if (dependencyEntryPoints.Any(x => string.Equals(x.DisplayName, dependencyEntryPoint.DisplayName)))
             {
@@ -121,7 +124,7 @@ internal partial class MethodDependencyMappingContext : IMethodDependencyMapping
 
         foreach (var dependencyEntryPoint in dependencyEntryPoints)
         {
-            await MapDownstream(dependencyEntryPoint, cancellationToken);
+            await MapDownstream(dependencyEntryPoint, projectFilter, cancellationToken);
         }
     }
 

--- a/src/Map/DependencyMapper/src/Filters/IFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/IFilter.cs
@@ -1,0 +1,22 @@
+﻿namespace Iceberg.Map.DependencyMapper.Filters;
+
+/// <summary>
+/// A generic interface used to defining filters.
+/// </summary>
+/// <typeparam name="T">The type which is being filtered.</typeparam>
+public interface IFilter<T> where T : class
+{
+    /// <summary>
+    /// Filters the input values based on the filtering implementation.
+    /// </summary>
+    /// <param name="input">The input values of the specified type <typeparamref name="T"/>.</param>
+    /// <returns>The filtered results.</returns>
+    IEnumerable<T> Filter(IEnumerable<T> input);
+
+    /// <summary>
+    /// Returns the <see cref="bool"/> result of the filtering predicate for an individual value.
+    /// </summary>
+    /// <param name="input">The input value of the specified type <typeparamref name="T"/>.</param>
+    /// <returns>The <see cref="bool"/> result of the predicate.</returns>
+    bool Predicate(T input);
+}

--- a/src/Map/DependencyMapper/src/Filters/Projects/AggregateProjectFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/Projects/AggregateProjectFilter.cs
@@ -1,0 +1,39 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+
+namespace Iceberg.Map.DependencyMapper.Filters.Projects;
+
+/// <summary>
+/// Aggregates <see cref="IProjectFilter"/> combining multiple <see cref="IProjectFilter"/> instances.
+/// </summary>
+public class AggregateProjectFilter : IProjectFilter
+{
+    private readonly IEnumerable<IProjectFilter> _projectFilters;
+
+    /// <summary>
+    /// Creates an <see cref="AggregateProjectFilter"/> instance.
+    /// </summary>
+    /// <param name="projectFilters">The <see cref="IProjectFilter"/> instances to aggregate.</param>
+    public AggregateProjectFilter(IEnumerable<IProjectFilter> projectFilters)
+    {
+        _projectFilters = projectFilters;
+    }
+    /// <summary>
+    /// Returns the filtered <see cref="IProjectWrapper"/> instances.
+    /// </summary>
+    /// <param name="projectWrappers">The input <see cref="IProjectWrapper"/> instances.</param>
+    /// <returns>The filtered <see cref="IProjectWrapper"/> instances.</returns>
+    public IEnumerable<IProjectWrapper> Filter(IEnumerable<IProjectWrapper> projectWrappers)
+    {
+        return projectWrappers.Where(project => _projectFilters.All(filter => filter.Predicate(project)));
+    }
+
+    /// <summary>
+    /// Returns the aggregate result of the filtering predicates for the provided <see cref="IProjectWrapper"/> instance.
+    /// </summary>
+    /// <param name="projectWrapper">The <see cref="IProjectWrapper"/> instance.</param>
+    /// <returns>The aggregate <see cref="bool"/> result of the filtering predicates.</returns>
+    public bool Predicate(IProjectWrapper projectWrapper)
+    {
+        return _projectFilters.All(filter => filter.Predicate(projectWrapper));
+    }
+}

--- a/src/Map/DependencyMapper/src/Filters/Projects/DefaultProjectFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/Projects/DefaultProjectFilter.cs
@@ -1,0 +1,24 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+
+namespace Iceberg.Map.DependencyMapper.Filters.Projects;
+
+/// <summary>
+/// The default <see cref="IProjectFilter"/> filter. Applies no filtering logic.
+/// </summary>
+public class DefaultProjectFilter : IProjectFilter
+{
+    /// <summary>
+    /// Returns the provided <see cref="IProjectWrapper"/> instances with no filtering logic applied.
+    /// </summary>
+    /// <param name="projectWrappers">The provided <see cref="IProjectWrapper"/> instances.</param>
+    /// <returns>The provided <see cref="IProjectWrapper"/> instances.</returns>
+    public IEnumerable<IProjectWrapper> Filter(IEnumerable<IProjectWrapper> projectWrappers) => projectWrappers;
+
+    /// <summary>
+    /// Returns the result of the filtering predicate for an individual <see cref="IProjectWrapper"/>.
+    /// Always returns <see cref="true"/> to return all input items, thus applying no filtering logic. 
+    /// </summary>
+    /// <param name="projectWrapper">The provided <see cref="IProjectWrapper"/> instance.</param>
+    /// <returns>Returns <see cref="true"/>.</returns>
+    public bool Predicate(IProjectWrapper projectWrapper) => true;
+}

--- a/src/Map/DependencyMapper/src/Filters/Projects/IProjectFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/Projects/IProjectFilter.cs
@@ -1,0 +1,10 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+
+namespace Iceberg.Map.DependencyMapper.Filters.Projects;
+
+/// <summary>
+/// An <see cref="IFilter{T}"/> used for filtering <see cref="IProjectWrapper"/> instances.
+/// </summary>
+public interface IProjectFilter : IFilter<IProjectWrapper>
+{
+}

--- a/src/Map/DependencyMapper/src/Filters/Projects/ProjectNameContainsFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/Projects/ProjectNameContainsFilter.cs
@@ -1,0 +1,70 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+
+namespace Iceberg.Map.DependencyMapper.Filters.Projects;
+
+/// <summary>
+/// An <see cref="IProjectFilter"/> which filters based on the <see cref="IProjectWrapper.Name"/>. 
+/// </summary>
+public class ProjectNameContainsFilter : IProjectFilter
+{
+    private readonly string _value;
+    private readonly ProjectNameContainsFilterType _filterType;
+    private readonly StringComparison _stringComparison;
+
+    /// <summary>
+    /// Creates and instance of <see cref="ProjectNameContainsFilter"/>.
+    /// </summary>
+    /// <param name="value">The value to check for in the project name.</param>
+    /// <param name="filterType">The <see cref="ProjectNameContainsFilterType"/> used to specify the filtering behavior.</param>
+    /// <param name="stringComparison">An optional <see cref="StringComparison"/>. Defaults to <see cref="StringComparison.CurrentCulture"/>.</param>
+    public ProjectNameContainsFilter(
+        string value,
+        ProjectNameContainsFilterType filterType,
+        StringComparison stringComparison = StringComparison.CurrentCulture)
+    {
+        _value = value;
+        _filterType = filterType;
+        _stringComparison = stringComparison;
+    }
+
+    /// <summary>
+    /// Returns the filtered <see cref="IProjectWrapper"/> instances.
+    /// </summary>
+    /// <param name="projectWrappers">The input <see cref="IProjectWrapper"/> instances.</param>
+    /// <returns>The filtered <see cref="IProjectWrapper"/> instances.</returns>
+    public IEnumerable<IProjectWrapper> Filter(IEnumerable<IProjectWrapper> projectWrappers)
+    {
+        return projectWrappers.Where(p => Predicate(p));
+    }
+
+    /// <summary>
+    /// Returns the result of the filtering predicate for the provided <see cref="IProjectWrapper"/> instance.
+    /// </summary>
+    /// <param name="projectWrapper">The <see cref="IProjectWrapper"/> instance.</param>
+    /// <returns>The <see cref="bool"/> result of the filtering predicate.</returns>
+    public bool Predicate(IProjectWrapper projectWrapper)
+    {
+        return _filterType switch
+        {
+            ProjectNameContainsFilterType.Exclude => !projectWrapper.Name.Contains(_value, _stringComparison),
+            ProjectNameContainsFilterType.Include => projectWrapper.Name.Contains(_value, _stringComparison),
+            _ => true
+        };
+    }
+
+    /// <summary>
+    /// The filtering behavior to use with the provided project names.
+    /// </summary>
+    public enum ProjectNameContainsFilterType
+    {
+        /// <summary>
+        /// Exclude projects with names that contain the specified text.
+        /// </summary>
+        Exclude,
+
+        /// <summary>
+        /// Include projects with names that contain the specified text.
+        /// </summary>
+        Include
+    }
+}

--- a/src/Map/DependencyMapper/src/Filters/Projects/ProjectNameFilter.cs
+++ b/src/Map/DependencyMapper/src/Filters/Projects/ProjectNameFilter.cs
@@ -1,0 +1,76 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+using Microsoft.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.Filters.Projects;
+
+/// <summary>
+/// An <see cref="IProjectFilter"/> which filters based on the <see cref="IProjectWrapper.Name"/>.
+/// </summary>
+public class ProjectNameFilter : IProjectFilter
+{
+    private readonly HashSet<string> _projectNames;
+    private readonly ProjectNameFilterType _filterType;
+
+    /// <summary>
+    /// Creates an instance of <see cref="ProjectNameFilter"/>.
+    /// </summary>
+    /// <param name="projectNames">An enumerable of project names to filter against. Corresponds to <see cref="IProjectWrapper.Name"/>.</param>
+    /// <param name="filterType">The <see cref="ProjectNameFilterType"/> used to specify the filtering behavior.</param>
+    /// <param name="stringComparer">An optional <see cref="StringComparer"/> instance. Defaults to <see cref="StringComparer.CurrentCulture"/>.</param>
+    public ProjectNameFilter(
+        IEnumerable<string> projectNames,
+        ProjectNameFilterType filterType,
+        StringComparer? stringComparer = null)
+    {
+        stringComparer ??= StringComparer.CurrentCulture;
+
+        _projectNames = projectNames.ToHashSet(stringComparer);
+        _filterType = filterType;
+    }
+
+    /// <summary>
+    /// Returns the filtered <see cref="IProjectWrapper"/> instances.
+    /// </summary>
+    /// <param name="projectWrappers">The input <see cref="IProjectWrapper"/> instances.</param>
+    /// <returns>The filtered <see cref="IProjectWrapper"/> instances.</returns>
+    public IEnumerable<IProjectWrapper> Filter(IEnumerable<IProjectWrapper> projectWrappers)
+    {
+        return _filterType switch
+        {
+            ProjectNameFilterType.Exclude => projectWrappers.Where(p => !_projectNames.Contains(p.Name)),
+            ProjectNameFilterType.Include => projectWrappers.Where(p => _projectNames.Contains(p.Name)),
+            _ => projectWrappers
+        };
+    }
+
+    /// <summary>
+    /// Returns the result of the filtering predicate for the provided <see cref="IProjectWrapper"/> instance.
+    /// </summary>
+    /// <param name="projectWrapper">The <see cref="IProjectWrapper"/> instance.</param>
+    /// <returns>The <see cref="bool"/> result of the filtering predicate.</returns>
+    public bool Predicate(IProjectWrapper projectWrapper)
+    {
+        return _filterType switch
+        {
+            ProjectNameFilterType.Exclude => !_projectNames.Contains(projectWrapper.Name),
+            ProjectNameFilterType.Include => _projectNames.Contains(projectWrapper.Name),
+            _ => true
+        };
+    }
+
+    /// <summary>
+    /// The filtering behavior to use with the provided project names.
+    /// </summary>
+    public enum ProjectNameFilterType
+    {
+        /// <summary>
+        /// Exclude projects with the specified names.
+        /// </summary>
+        Exclude,
+
+        /// <summary>
+        /// Include projects with the specified names.
+        /// </summary>
+        Include
+    }
+}

--- a/src/Map/DependencyMapper/src/MethodDependencyMapper.cs
+++ b/src/Map/DependencyMapper/src/MethodDependencyMapper.cs
@@ -1,4 +1,5 @@
 ﻿using Iceberg.Map.DependencyMapper.Context;
+using Iceberg.Map.DependencyMapper.Filters.Projects;
 using Iceberg.Map.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
@@ -20,6 +21,7 @@ public interface IMethodDependencyMapper
     Task<MethodDependencyMap> MapDownstream(
         IMethodSolutionContext solutionContext,
         IEnumerable<IEntryPoint<MethodDeclarationSyntax>> methodEntryPoints,
+        IProjectFilter? projectFilter = null,
         CancellationToken cancellationToken = default);
 }
 
@@ -64,15 +66,18 @@ public sealed partial class MethodDependencyMapper : IMethodDependencyMapper
     public async Task<MethodDependencyMap> MapDownstream(
         IMethodSolutionContext solutionContext,
         IEnumerable<IEntryPoint<MethodDeclarationSyntax>> methodEntryPoints,
+        IProjectFilter? projectFilter = null,
         CancellationToken cancellationToken = default)
     {
         Log.DownstreamMethodDependencyMappingStart(_logger);
+
+        projectFilter ??= new DefaultProjectFilter();
 
         var methodDependencyMappingContext = new MethodDependencyMappingContext(_loggerFactory, solutionContext);
 
         foreach (var entryPoint in methodEntryPoints)
         {
-            await methodDependencyMappingContext.MapDownstream(entryPoint, cancellationToken);
+            await methodDependencyMappingContext.MapDownstream(entryPoint, projectFilter, cancellationToken);
         }
 
         Log.DownstreamMethodDependencyMappingEnd(_logger);

--- a/src/Map/DependencyMapper/src/Wrappers/ProjectWrapper.cs
+++ b/src/Map/DependencyMapper/src/Wrappers/ProjectWrapper.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.Wrappers;
+
+public interface IProjectWrapper
+{
+    /// <summary>
+    /// The underlying <see cref="Microsoft.CodeAnalysis.Project"/> instance.
+    /// </summary>
+    Project Project { get; }
+
+    /// <summary>
+    /// The <see cref="Microsoft.CodeAnalysis.Project.Name"/> of the underlying instance.
+    /// </summary>
+    string Name { get; }
+}
+
+/// <summary>
+/// Wrapper class for <see cref="Microsoft.CodeAnalysis.Project"/>.
+/// </summary>
+public class ProjectWrapper : IProjectWrapper
+{
+    /// <inheritdoc/>
+    public Project Project { get; }
+
+    /// <inheritdoc/>
+    public string Name => Project.Name;
+
+    /// <summary>
+    /// Creates an instance of <see cref="ProjectWrapper"/>.
+    /// </summary>
+    /// <param name="project">The <see cref="Microsoft.CodeAnalysis.Project"/> instance to wrap.</param>
+    public ProjectWrapper(Project project)
+    {
+        Project = project;
+    }
+}

--- a/src/Map/DependencyMapper/src/Wrappers/SolutionWrapper.cs
+++ b/src/Map/DependencyMapper/src/Wrappers/SolutionWrapper.cs
@@ -5,14 +5,15 @@ namespace Iceberg.Map.DependencyMapper.Wrappers;
 public interface ISolutionWrapper
 {
     /// <summary>
-    /// The underlying <see cref="Microsoft.CodeAnalysis.Solution"/>.
+    /// The underlying <see cref="Microsoft.CodeAnalysis.Solution"/> instance.
     /// </summary>
-    Solution Solution { get; init; }
+    Solution Solution { get; }
 
     /// <summary>
-    /// The <see cref="Project"/> instances contained in the <see cref="Microsoft.CodeAnalysis.Solution"/>.
+    /// The <see cref="Project"/> instances contained in the <see cref="Microsoft.CodeAnalysis.Solution"/>
+    /// wrapper in <see cref="ProjectWrapper"/>.
     /// </summary>
-    IEnumerable<Project> Projects { get; }
+    IEnumerable<ProjectWrapper> Projects { get; }
 }
 
 /// <summary>
@@ -21,13 +22,18 @@ public interface ISolutionWrapper
 public class SolutionWrapper : ISolutionWrapper
 {
     /// <inheritdoc />
-    public Solution Solution { get; init; }
+    public Solution Solution { get; }
 
     /// <inheritdoc />
-    public IEnumerable<Project> Projects => Solution.Projects;
+    public IEnumerable<ProjectWrapper> Projects { get; }
 
+    /// <summary>
+    /// Creates an instance of <see cref="SolutionWrapper"/>.
+    /// </summary>
+    /// <param name="solution">The <see cref="Microsoft.CodeAnalysis.Solution"/> instance to wrap.</param>
     public SolutionWrapper(Solution solution)
     {
         Solution = solution;
+        Projects = solution.Projects.Select(p => new ProjectWrapper(p));
     }
 }

--- a/src/Map/DependencyMapper/test/FunctionalTests/DownstreamMethodDependencyMapperTests.cs
+++ b/src/Map/DependencyMapper/test/FunctionalTests/DownstreamMethodDependencyMapperTests.cs
@@ -253,10 +253,7 @@ public class DownstreamMethodDependencyMapperTests
         {
             {
                 new MethodMetadata("MyClass.Fibonacci(int, int, int)", "MyClass.cs"),
-                new HashSet<MethodMetadata>
-                {
-                    new MethodMetadata("MyClass.Fibonacci(int, int, int)", "MyClass.cs")
-                }
+                new HashSet<MethodMetadata>()
             }
         };
 
@@ -402,7 +399,7 @@ public class DownstreamMethodDependencyMapperTests
         AssertGeneratedDependencyMap(expected, actual);
     }
 
-    [Fact(Skip = "Unknown Issue")]
+    [Fact]
     public async Task OverriddenVirtualMethodCallingBaseImplementation()
     {
         // Arrange
@@ -719,6 +716,7 @@ public class DownstreamMethodDependencyMapperTests
             NullLoggerFactory.Instance,
             methodSelectors,
             solutionWrapper,
+            symbolEqualityComparer,
             symbolFinder);
     }
 }

--- a/src/Map/DependencyMapper/test/FunctionalTests/UpstreamMethodDependencyMapperTests.cs
+++ b/src/Map/DependencyMapper/test/FunctionalTests/UpstreamMethodDependencyMapperTests.cs
@@ -715,6 +715,7 @@ public class UpstreamMethodDependencyMapperTests
             NullLoggerFactory.Instance, 
             methodSelectors, 
             solutionWrapper, 
+            symbolEqualityComparer,
             symbolFinder);
     }
 }

--- a/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/AggregateProjectFilterTests.cs
+++ b/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/AggregateProjectFilterTests.cs
@@ -1,0 +1,77 @@
+﻿using Iceberg.Map.DependencyMapper.Filters.Projects;
+using Iceberg.Map.DependencyMapper.Wrappers;
+using Moq;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.UnitTests.Filters.Projects;
+
+[ExcludeFromCodeCoverage]
+public class AggregateProjectFilterTests
+{
+    public static IEnumerable<object[]> GetPredicateFilterTestData()
+    {
+        yield return new object[] { new bool[] { true } };
+        yield return new object[] { new bool[] { false } };
+
+        yield return new object[] { new bool[] { true, true } };
+        yield return new object[] { new bool[] { true, false } };
+        yield return new object[] { new bool[] { false, false } };
+        yield return new object[] { new bool[] { false, true } };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetPredicateFilterTestData))]
+    public void Filter(bool[] predicateResults)
+    {
+        // Arrange
+        var mockProjectFilters = GetMockProjectFilters(predicateResults);
+        var projectFilters = mockProjectFilters.Select(x => x.Object);
+
+        var projectWrapper = new Mock<IProjectWrapper>().Object;
+
+        var aggregateProjectFilter = new AggregateProjectFilter(projectFilters);
+
+        var expectedResultCount = predicateResults.All(x => x) ? 1 : 0;
+
+        // Act
+        var results = aggregateProjectFilter.Filter(new[] { projectWrapper });
+
+        // Assert
+        Assert.Equal(expectedResultCount, results.Count());
+    }
+
+    [Theory]
+    [MemberData(nameof(GetPredicateFilterTestData))]
+    public void Predicate(bool[] predicateResults)
+    {
+        // Arrange
+        var mockProjectFilters = GetMockProjectFilters(predicateResults);
+        var projectFilters = mockProjectFilters.Select(x => x.Object);
+
+        var projectWrapper = new Mock<IProjectWrapper>().Object;
+
+        var aggregateProjectFilter = new AggregateProjectFilter(projectFilters);
+
+        var expected = predicateResults.All(x => x);
+
+        // Act
+        var actual = aggregateProjectFilter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    private static IEnumerable<Mock<IProjectFilter>> GetMockProjectFilters(bool[] predicateResults)
+    {
+        return predicateResults.Select(result =>
+        {
+            var mock = new Mock<IProjectFilter>();
+
+            mock.Setup(x => x.Predicate(It.IsAny<IProjectWrapper>()))
+                .Returns(result);
+
+            return mock;
+        })
+        .ToList();
+    }
+}

--- a/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/DefaultProjectFilterTests.cs
+++ b/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/DefaultProjectFilterTests.cs
@@ -1,0 +1,42 @@
+﻿using Iceberg.Map.DependencyMapper.Filters.Projects;
+using Microsoft.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.UnitTests.Filters.Projects;
+
+[ExcludeFromCodeCoverage]
+public class DefaultProjectFilterTests
+{
+    [Fact]
+    public void Filter_ReturnsUnfilteredProjects()
+    {
+        // Arrange
+        var filter = new DefaultProjectFilter();
+
+        var mockProjectWrappers = Enumerable.Range(1, 3)
+            .Select(i => TestUtilities.GetMockProjectWrapper(i.ToString())).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Equal(projectWrappers, results);
+    }
+
+    [Fact]
+    public void Predicate_AlwaysReturnsTrue()
+    {
+        // Arrange
+        var filter = new DefaultProjectFilter();
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(string.Empty);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var result = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.True(result);
+    }
+}

--- a/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/ProjectNameContainsFilterTests.cs
+++ b/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/ProjectNameContainsFilterTests.cs
@@ -1,0 +1,182 @@
+﻿using Iceberg.Map.DependencyMapper.Filters.Projects;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.UnitTests.Filters.Projects;
+
+[ExcludeFromCodeCoverage]
+public class ProjectNameContainsFilterTests
+{
+    [Fact]
+    public void Filter_Exclude_DefaultComparer()
+    {
+        // Arrange
+        var textToExclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToExclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Exclude);
+
+        var allProjectNames = new[] { "ProjectA.Test", "ProjectB.test" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Single(results, x => x.Name == "ProjectB.test");
+    }
+
+    [Fact]
+    public void Filter_Exclude_CaseInsensitive()
+    {
+        // Arrange
+        var textToExclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToExclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Exclude,
+            StringComparison.CurrentCultureIgnoreCase);
+
+        var allProjectNames = new[] { "ProjectA.Test", "ProjectB.test" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Filter_Include_DefaultComparer()
+    {
+        // Arrange
+        var textToInclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToInclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Include);
+
+        var allProjectNames = new[] { "ProjectA.Test", "ProjectB.test" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Single(results, x => x.Name == "ProjectA.Test");
+    }
+
+    [Fact]
+    public void Filter_Include_CaseInsensitive()
+    {
+        // Arrange
+        var textToInclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToInclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Include,
+            StringComparison.CurrentCultureIgnoreCase);
+
+        var allProjectNames = new[] { "ProjectA.Test", "ProjectB.test" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Equal(2, results.Count());
+        Assert.Contains(results, x => x.Name == "ProjectA.Test");
+        Assert.Contains(results, x => x.Name == "ProjectB.test");
+    }
+
+    [Theory]
+    [InlineData("ProjectA.Test", false)]
+    [InlineData("ProjectB.test", true)]
+    public void Predicate_Exclude_DefaultComparer(string projectName, bool expected)
+    {
+        // Arrange
+        var textToExclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToExclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Exclude);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectA.Test", false)]
+    [InlineData("ProjectB.test", false)]
+    public void Predicate_Exclude_CaseInsensitive(string projectName, bool expected)
+    {
+        // Arrange
+        var textToExclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+           textToExclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Exclude,
+            StringComparison.CurrentCultureIgnoreCase);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectA.Test", true)]
+    [InlineData("ProjectB.test", false)]
+    public void Predicate_Include_DefaultComparer(string projectName, bool expected)
+    {
+        // Arrange
+        var textToInclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToInclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Include);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrappers = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrappers);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectA.Test", true)]
+    [InlineData("ProjectB.test", true)]
+    public void Predicate_Include_CaseInsensitive(string projectName, bool expected)
+    {
+        // Arrange
+        var textToInclude = "Test";
+        var filter = new ProjectNameContainsFilter(
+            textToInclude,
+            ProjectNameContainsFilter.ProjectNameContainsFilterType.Include,
+            StringComparison.CurrentCultureIgnoreCase);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/ProjectNameFilterTests.cs
+++ b/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/ProjectNameFilterTests.cs
@@ -1,0 +1,182 @@
+﻿using Iceberg.Map.DependencyMapper.Filters.Projects;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.UnitTests.Filters.Projects;
+
+[ExcludeFromCodeCoverage]
+public class ProjectNameFilterTests
+{
+    [Fact]
+    public void Filter_Exclude_DefaultComparer()
+    {
+        // Arrange
+        var projectNamesToExclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToExclude,
+            ProjectNameFilter.ProjectNameFilterType.Exclude);
+
+        var allProjectNames = new[] { "ProjectName", "projectname" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Single(results, x => x.Name == "projectname");
+    }
+
+    [Fact]
+    public void Filter_Exclude_CaseInsensitive()
+    {
+        // Arrange
+        var projectNamesToExclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToExclude,
+            ProjectNameFilter.ProjectNameFilterType.Exclude,
+            StringComparer.CurrentCultureIgnoreCase);
+
+        var allProjectNames = new[] { "ProjectName", "projectname" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Filter_Include_DefaultComparer()
+    {
+        // Arrange
+        var projectNamesToInclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToInclude,
+            ProjectNameFilter.ProjectNameFilterType.Include);
+
+        var allProjectNames = new[] { "ProjectName", "projectname" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Single(results, x => x.Name == "ProjectName");
+    }
+
+    [Fact]
+    public void Filter_Include_CaseInsensitive()
+    {
+        // Arrange
+        var projectNamesToInclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToInclude,
+            ProjectNameFilter.ProjectNameFilterType.Include,
+            StringComparer.CurrentCultureIgnoreCase); 
+
+        var allProjectNames = new[] { "ProjectName", "projectname" };
+        var mockProjectWrappers = allProjectNames
+            .Select(name => TestUtilities.GetMockProjectWrapper(name)).ToList();
+        var projectWrappers = mockProjectWrappers.Select(x => x.Object);
+
+        // Act
+        var results = filter.Filter(projectWrappers);
+
+        // Assert
+        Assert.Equal(2, results.Count());
+        Assert.Contains(results, x => x.Name == "ProjectName");
+        Assert.Contains(results, x => x.Name == "projectname");
+    }
+
+    [Theory]
+    [InlineData("ProjectName", false)]
+    [InlineData("projectname", true)]
+    public void Predicate_Exclude_DefaultComparer(string projectName, bool expected)
+    {
+        // Arrange
+        var projectNamesToExclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToExclude,
+            ProjectNameFilter.ProjectNameFilterType.Exclude);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectName", false)]
+    [InlineData("projectname", false)]
+    public void Predicate_Exclude_CaseInsensitive(string projectName, bool expected)
+    {
+        // Arrange
+        var projectNamesToExclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToExclude,
+            ProjectNameFilter.ProjectNameFilterType.Exclude,
+            StringComparer.CurrentCultureIgnoreCase);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectName", true)]
+    [InlineData("projectname", false)]
+    public void Predicate_Include_DefaultComparer(string projectName, bool expected)
+    {
+        // Arrange
+        var projectNamesToInclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToInclude,
+            ProjectNameFilter.ProjectNameFilterType.Include);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrappers = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrappers);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("ProjectName", true)]
+    [InlineData("projectname", true)]
+    public void Predicate_Include_CaseInsensitive(string projectName, bool expected)
+    {
+        // Arrange
+        var projectNamesToInclude = new[] { "ProjectName" };
+        var filter = new ProjectNameFilter(
+            projectNamesToInclude,
+            ProjectNameFilter.ProjectNameFilterType.Include,
+            StringComparer.CurrentCultureIgnoreCase);
+
+        var mockProjectWrapper = TestUtilities.GetMockProjectWrapper(projectName);
+        var projectWrapper = mockProjectWrapper.Object;
+
+        // Act
+        var actual = filter.Predicate(projectWrapper);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/TestUtilities.cs
+++ b/src/Map/DependencyMapper/test/UnitTests/Filters/Projects/TestUtilities.cs
@@ -1,0 +1,19 @@
+﻿using Iceberg.Map.DependencyMapper.Wrappers;
+using Moq;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Iceberg.Map.DependencyMapper.UnitTests.Filters.Projects;
+
+[ExcludeFromCodeCoverage]
+public static class TestUtilities
+{
+    public static Mock<IProjectWrapper> GetMockProjectWrapper(string projectName)
+    {
+        var mockProjectWrapper = new Mock<IProjectWrapper>();
+
+        mockProjectWrapper.SetupGet(x => x.Name)
+            .Returns(projectName);
+
+        return mockProjectWrapper;
+    }
+}


### PR DESCRIPTION
- Adds the basic classes and interfaces for projects filters (default, name equals, name contains)
- Adds additional classes and interfaces for wrapping built-in Roslyn types
- Minor fixes and clean up

Fixes #4 